### PR TITLE
Warning elimination

### DIFF
--- a/Choplifter.ino
+++ b/Choplifter.ino
@@ -6,7 +6,7 @@
 #include "src/sounds/Sounds.h"
 
 Arduboy2Ext arduboy;
-ArduboyTones sound(arduboy.audio.on);
+ArduboyTones sound(arduboy.audio.enabled);
 
 Helicopter heli;
 

--- a/Choplifter_HostageMovements.ino
+++ b/Choplifter_HostageMovements.ino
@@ -162,7 +162,7 @@ void hostageMovements() {
           if (hostage->xPos < HOSTAGE_FAR_RIGHT_POS) { randomTopLimit = HostageStance::Running_Left_4; }  // Prevent hostage from crossing fence ..      
           if (hostage->xPos > HOSTAGE_FAR_LEFT_POS)  { randomLowerLimit = HostageStance::Running_Right_1; }  // Prevent hostage from crossing fence ..      
 
-          hostage->stance = (HostageStance)random((uint8_t)HostageStance::Running_Left_1, (uint8_t)randomTopLimit + 1);
+          hostage->stance = (HostageStance)random((uint8_t)randomLowerLimit, (uint8_t)randomTopLimit + 1);
 
           switch (hostage->stance) {
 

--- a/Choplifter_PlayerMovements.ino
+++ b/Choplifter_PlayerMovements.ino
@@ -75,6 +75,7 @@ void playerMovements() {
 
           break;
 
+          default: break;
       }
 
     }


### PR DESCRIPTION
Eliminates all but one warning.
Saves 8 bytes of progmem as a side effect.